### PR TITLE
createVNode 로직 구현

### DIFF
--- a/src/components/posts/Post.jsx
+++ b/src/components/posts/Post.jsx
@@ -1,5 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../../lib";
 import { toTimeFormat } from "../../utils/index.js";
 
 export const Post = ({

--- a/src/components/posts/PostForm.jsx
+++ b/src/components/posts/PostForm.jsx
@@ -1,6 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../../lib";
-
 export const PostForm = () => {
   return (
     <div className="mb-4 bg-white rounded-lg shadow p-4">

--- a/src/components/templates/Footer.jsx
+++ b/src/components/templates/Footer.jsx
@@ -1,6 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../../lib";
-
 export const Footer = () => (
   <footer className="bg-gray-200 p-4 text-center">
     <p>&copy; 2024 항해플러스. All rights reserved.</p>

--- a/src/components/templates/Header.jsx
+++ b/src/components/templates/Header.jsx
@@ -1,6 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../../lib";
-
 export const Header = () => {
   return (
     <header className="bg-blue-600 text-white p-4 sticky top-0">

--- a/src/components/templates/Navigation.jsx
+++ b/src/components/templates/Navigation.jsx
@@ -1,5 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../../lib";
 import { router } from "../../router";
 import { globalStore } from "../../stores";
 

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,11 @@
 export function createVNode(type, props, ...children) {
-  return {};
+  return {
+    type,
+    props,
+    children: children.flat(Infinity).filter((item) => {
+      if (item === 0) return true;
+      if (!item) return false;
+      return true;
+    }),
+  };
 }

--- a/src/main.hash.jsx
+++ b/src/main.hash.jsx
@@ -1,5 +1,4 @@
-/** @jsx createVNode */
-import { createHashRouter, createVNode } from "./lib";
+import { createHashRouter } from "./lib";
 import { HomePage, LoginPage, ProfilePage } from "./pages";
 import { globalStore } from "./stores";
 import { ForbiddenError, UnauthorizedError } from "./errors";

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,4 @@
-/** @jsx createVNode */
-import { createRouter, createVNode } from "./lib";
+import { createRouter } from "./lib";
 import { HomePage, LoginPage, ProfilePage } from "./pages";
 import { globalStore } from "./stores";
 import { ForbiddenError, UnauthorizedError } from "./errors";

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../lib";
-
 import { Footer, Header, Navigation, Post, PostForm } from "../components";
 import { globalStore } from "../stores";
 

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,5 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../lib";
 import { globalStore } from "../stores";
 import { userStorage } from "../storages";
 

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,6 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../lib";
-
 export const NotFoundPage = () => (
   <main className="bg-gray-100 flex items-center justify-center min-h-screen">
     <div

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,5 +1,3 @@
-/** @jsx createVNode */
-import { createVNode } from "../lib";
 import { Footer, Header, Navigation } from "../components";
 import { globalStore } from "../stores";
 import { userStorage } from "../storages";

--- a/src/render.jsx
+++ b/src/render.jsx
@@ -1,8 +1,7 @@
-/** @jsx createVNode */
 // 초기화 함수
 import { router } from "./router";
 import { ForbiddenError, UnauthorizedError } from "./errors";
-import { renderElement, createVNode } from "./lib";
+import { renderElement } from "./lib";
 import { NotFoundPage } from "./pages";
 
 export function render() {


### PR DESCRIPTION
createVNode를 로직을 구현하면서 jsx를 어떻게 트랜스파일하는지 궁금증이 생겼다.
조사를 해보니 vite의 esbuild는 babel 없이도 jsx를 사용할 수 있는데,
[jsxFactory](https://esbuild.github.io/api/#jsx-factory)의 기본 값이 React.createElement를 사용하는 것으로 동작하기 때문이다.

따라서 react를 설치하지 않았을 경우에는 동작하지 않는데,
```js
export default mergeConfig(
  defineConfig({
    esbuild: {
      jsxFactory: "createVNode",
    },
    optimizeDeps: {
      esbuildOptions: {
        jsx: "transform",
        jsxFactory: "createVNode",
      },
    },
  }),
  defineTestConfig({
    test: {
      globals: true,
      environment: "jsdom",
      setupFiles: "./src/setupTests.js",
      exclude: ["**/e2e/**", "**/*.e2e.spec.js", "**/node_modules/**"],
    },
  }),
);
```
[jsxFactory](https://esbuild.github.io/api/#jsx-factory)에 함수를 정의해서 jsx 변환 때 사용이 되도록 할 수 있다. 
파일별로 구성하려면 `// @jsx createVNode`와 같이 주석을 사용하여 구성할 수도 있다. JSX가 `automatic`으로 설정된 경우에는 이 설정이 적용되지 않는다.

>  파일별로 구성하려면 `// @jsx createVNode`와 같이 주석을 사용하여 구성할 수도 있다.

jsxFactory에 설정하면 esbuild가 jsx를 트랜스파일링 할 때 함수를 사용하고, 파일별로 다르게 설정하는 것은 주석을 통해서 가능하다는 것으로 이해가 되었다.
그래서 파일별로 `// @jsx createVNode`주석이 없어도 되지 않을까하는 가설을 세워서 지워 보았는데 잘 동작하는 것 같다.
구현이 완료 될 때까지 잘 동작 하는지 확인해보아야 겠다.